### PR TITLE
Support files that do not exist.

### DIFF
--- a/osview/__init__.py
+++ b/osview/__init__.py
@@ -52,13 +52,21 @@ def merge_files(manifest, workspace):
     for name, data in manifest["files"].items():
         created_by_action = data["created_by_action"]
         path = workspace / name
+
         data["path"] = path
         data["type"] = path.suffixes[0].lstrip(".")
+        if path.exists():
+            data["exists"] = True
+            data["filesize"] = path.stat().st_size
 
-        if data["type"] == "csv":
-            html, truncated = csv_to_html(path, Path(name))
-            data["html"] = html
-            data["truncated"] = truncated
+            # build preview
+            if data["type"] == "csv":
+                html, truncated = csv_to_html(path, Path(name))
+                data["html"] = html
+                data["truncated"] = truncated
+        else:
+            data["exists"] = False
+            data["filesize"] = 0
 
         actions[created_by_action]["files"][name] = data
 

--- a/osview/templates/workspace.html
+++ b/osview/templates/workspace.html
@@ -47,6 +47,10 @@
           font-weight: bold;
         }
 
+        .filelink.not-exist { 
+            text-decoration: line-through;
+        }
+
         .file, .filelist { display: none; }
         .file.active, .filelist.active { display: block; }
 
@@ -70,7 +74,7 @@
           </div>
           <ul id="{{ name }}-filelist" class="filelist">
             {% for filename, file in action['files'].items() %}
-            <li data-show="{{ filename }}" data-hide=".file" data-highlight=".filelink" class="filelink {{file.privacy_level}}">{{ filename }}</li>
+            <li data-show="{{ filename }}" data-hide=".file" data-highlight=".filelink" class="filelink {{file.privacy_level}} {{ '' if file.exists else 'not-exist' }}">{{ filename }}</li>
             {% endfor %}
           </ul>
         </li>
@@ -80,29 +84,33 @@
       <div class="column content">
         {% for name, action in actions.items() %}
         {% for filename, file in action.files.items() %}
-        <section id="{{ filename }}" class="{{ file.type }} file">
+        <section id="{{ filename }}" class="{{ file.type }} file {{ '' if file.exists else 'not-exist' }}">
           <div class="summary">
             <table>
               <tr><th>Name</th><td>{{ filename }}</td></tr>
-              <tr><th>Size</th><td>{{ file.path.stat().st_size }}</td></tr>
+              <tr><th>Size</th><td>{{ file.filesize }}</td></tr>
               <tr><th>Privacy</th><td>{{ file.privacy_level }}</td></tr>
               <tr><th>Action</th><td>{{ name }}</td></tr>
             </table>
           </div>
           <div class="contents">
-            {% if file.html %}
-            {% if file.truncated %}
-            <p>This CSV is very large, and this preview has been truncated.</p>
-            {% endif %}
-            <div data-load="{{ file.html }}"/>
-            {% elif file.type in ("jpeg", "png", "svg") %}
-            <img data-load="{{ filename }}"/>
-            {% elif file.type in ("log", "txt") %}
-            <pre data-load="{{ filename }}"/>
-            {% elif file.type in ("html") %}
-            <iframe data-load="{{ filename }}" sandbox="allow-same-origin allow-scripts"></iframe>
+            {% if file.exists %}
+                {% if file.html %}
+                    {% if file.truncated %}
+                    <p>This CSV is very large, and this preview has been truncated.</p>
+                    {% endif %}
+                <div data-load="{{ file.html }}"/>
+                {% elif file.type in ("jpeg", "png", "svg") %}
+                <img data-load="{{ filename }}"/>
+                {% elif file.type in ("log", "txt") %}
+                <pre data-load="{{ filename }}"/>
+                {% elif file.type in ("html") %}
+                <iframe data-load="{{ filename }}" sandbox="allow-same-origin allow-scripts"></iframe>
+                {% else %}
+                <p>We cannot display this file type, but you can download it: <a href="{{ filename }}">{{ filename }}</a></p>
+                {% endif %}
             {% else %}
-            <p>We cannot display this file type, but you can download it: <a href="{{ filename }}">{{ filename }}</a></p>
+            <p>This file is not present</p>
             {% endif %}
           </div>
         </section>


### PR DESCRIPTION
Inclused some minimal html classes and styles.

Reasons a file listed in project.yaml might not be present:

1. project yaml is out of date with actual files generated
2. action did not succeed and thus file was not generated
3. we are viewing this from level 4/medium_privacy and thus no
   high_privacy files exist.